### PR TITLE
Fix for Fast FastMetabolism ignoring EnableSoldierAdjustments

### DIFF
--- a/Source/AssortedAdjustments/AssortedAdjustments.csproj
+++ b/Source/AssortedAdjustments/AssortedAdjustments.csproj
@@ -135,14 +135,13 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>
-rd /s /q "$(SolutionDir)..\Release\"
+    <PostBuildEvent>rd /s /q "$(SolutionDir)..\Release\"
 xcopy "$(ProjectDir)README.md" "$(SolutionDir)..\" /Y
 xcopy "$(ProjectDir)changelog.txt" "$(SolutionDir)..\" /Y
 xcopy "$(TargetPath)" "$(SolutionDir)..\Release\$(TargetName)\" /Y
 xcopy "$(ProjectDir)README.md" "$(SolutionDir)..\Release\$(TargetName)\" /Y
 xcopy "$(ProjectDir)changelog.txt" "$(SolutionDir)..\Release\$(TargetName)\" /Y
-xcopy "$(SolutionDir)..\Release\*.*" "C:\Users\Mad\Documents\My Games\Phoenix Point\Mods\" /S /Y
-    </PostBuildEvent>
+xcopy "$(SolutionDir)..\Release\*.*" "%25USERPROFILE%25\Documents\My Games\Phoenix Point\Mods\" /S /Y
+</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Source/AssortedAdjustments/Patches/ModifyDamageOverTimeStatus.cs
+++ b/Source/AssortedAdjustments/Patches/ModifyDamageOverTimeStatus.cs
@@ -11,7 +11,7 @@ namespace AssortedAdjustments.Patches
         {
             public static bool Prepare()
             {
-                return AssortedAdjustments.Settings.FastMetabolism;
+                return AssortedAdjustments.Settings.EnableSoldierAdjustments && AssortedAdjustments.Settings.FastMetabolism;
             }
 
             public static void Prefix(DamageOverTimeStatus __instance, ref float amount)

--- a/Source/AssortedAdjustments/Settings.cs
+++ b/Source/AssortedAdjustments/Settings.cs
@@ -276,7 +276,7 @@ namespace AssortedAdjustments
         public int TiredStatusStaminaBelow = 30;
         [Annotation("Soldiers will get the status 'Exhausted' when their stamina falls be below this value (percentage), vanilla default is 0%", "10")]
         public int ExhaustedStatusStaminaBelow = 10;
-        [Annotation("Soldiers will recover from beeing paralysed or infected much faster", "true")]
+        [Annotation("Soldiers will recover from beeing paralysed or infected much faster", "True")]
         public bool FastMetabolism = true;
 
 


### PR DESCRIPTION
FastMetabolism includes EnableSoldierAdjustments checks.
Changed Post Build events to use USERPROFILE env from hard coded user name.
Changed FastMetabolism's default Annotation from true to True.  Fixes settings-reference showing the default as bold.

Bug #13